### PR TITLE
Add CORS support for frontend connection

### DIFF
--- a/GreenhouseApi/Program.cs
+++ b/GreenhouseApi/Program.cs
@@ -5,7 +5,6 @@ using EFCGreenhouse;
 using GreenhouseApi.Services;
 using Microsoft.EntityFrameworkCore;
 
-
 var builder = WebApplication.CreateBuilder(args);
 
 // 🔹 Register services
@@ -28,8 +27,16 @@ builder.Services.AddScoped<IPredictionLogRepository, PredictionLogRepository>();
 builder.Services.AddDbContext<GreenhouseDbContext>(options =>
     options.UseSqlite("Data Source=greenhouse.db"));
 
-
-
+// 🔹 Add CORS policy
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy =>
+    {
+        policy.WithOrigins("http://localhost:5173")  // for the frontend
+              .AllowAnyHeader()
+              .AllowAnyMethod();
+    });
+});
 
 var app = builder.Build();
 
@@ -45,16 +52,18 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
+app.UseRouting();     // 🔹 (IMPORTANT for CORS!)
+
+app.UseCors();        // 🔹 (Enable CORS AFTER routing)
+
+app.UseAuthorization();
+
 // 🔹 Map controllers
-app.MapControllers();  // 👈 This is MISSING in your code
-
-
-
-
-
+app.MapControllers();
 
 app.Run();
 
+// (WeatherForecast record is not needed for your app, but it's okay to leave it)
 record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
 {
     public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);


### PR DESCRIPTION
This PR adds CORS configuration to allow the frontend (localhost:5173) to fetch data from the backend API (localhost:5055) during development.